### PR TITLE
docs: add npm package links

### DIFF
--- a/.changeset/clean-npm-links.md
+++ b/.changeset/clean-npm-links.md
@@ -1,0 +1,5 @@
+---
+"rehype-code-group": patch
+---
+
+Refresh the npm package README to remove the retired playground, link to the npm package page, and clarify the current documentation and Cloudflare Pages setup.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Accessible, framework-neutral code tabs for rehype. Group highlighted code or arbitrary content, synchronize related choices, persist state, and choose exactly how browser assets are delivered.
 
-[Documentation](https://rehype-code-group.pages.dev/) · [Live playground](https://rehype-code-group.pages.dev/#try-heading) · [Report an issue](https://github.com/ITZSHOAIB/rehype-code-group/issues)
+[Documentation](https://rehype-code-group.pages.dev/) · [npm](https://www.npmjs.com/package/rehype-code-group) · [Report an issue](https://github.com/ITZSHOAIB/rehype-code-group/issues)
 
 ## Why use it?
 
@@ -257,14 +257,14 @@ See the [framework guide](https://rehype-code-group.pages.dev/guides/frameworks/
 
 ## Documentation site
 
-The documentation is a fully static [Vocs](https://vocs.dev/) site with live, production-package previews.
+The documentation is a fully static [Vocs](https://vocs.dev/) site with interactive examples powered by the package's public browser client and stylesheet.
 
 ```sh
 pnpm docs:dev
 pnpm docs:build
 ```
 
-For Cloudflare Pages, use `pnpm docs:build` as the build command and `docs/dist/public` as the output directory. Set `VOCS_BASE_URL` to the deployed site URL when canonical absolute URLs are required; it is intentionally optional so local previews use relative assets.
+For Cloudflare Pages, keep the repository root as the project root, use `pnpm docs:build` as the build command, and use `docs/dist/public` as the output directory. Set `VOCS_BASE_URL` to the canonical deployed URL in the production environment only; leave it unset for local and branch previews so their assets and navigation remain self-contained.
 
 ## Quality and security
 

--- a/docs/src/components/LandingHero.tsx
+++ b/docs/src/components/LandingHero.tsx
@@ -2,6 +2,7 @@ import ArrowUpRight from "~icons/lucide/arrow-up-right";
 import BookOpen from "~icons/lucide/book-open";
 import Github from "~icons/lucide/github";
 import PackageCheck from "~icons/lucide/package-check";
+import Npm from "~icons/simple-icons/npm";
 import { CodeGroupPreview } from "./CodeGroupPreview.js";
 import { ProofPoints } from "./ProofPoints.js";
 
@@ -38,6 +39,13 @@ export function LandingHero() {
             >
               <Github aria-hidden="true" />
               GitHub
+            </a>
+            <a
+              className="rcg-home-button"
+              href="https://www.npmjs.com/package/rehype-code-group"
+            >
+              <Npm aria-hidden="true" />
+              View on npm
             </a>
           </div>
         </div>

--- a/docs/src/components/ProofPoints.tsx
+++ b/docs/src/components/ProofPoints.tsx
@@ -4,11 +4,15 @@ import ShieldCheck from "~icons/lucide/shield-check";
 export function ProofPoints() {
   return (
     <section aria-label="Project highlights" className="rcg-home-proof">
-      <div className="rcg-home-proof-lead">
+      <a
+        aria-label="View rehype-code-group download statistics on npm"
+        className="rcg-home-proof-lead"
+        href="https://www.npmjs.com/package/rehype-code-group"
+      >
         <span className="rcg-home-proof-kicker">Used in the wild</span>
         <strong>16k</strong>
         <p>downloads in the last 30 days</p>
-      </div>
+      </a>
       <div className="rcg-home-proof-details">
         <article>
           <Keyboard aria-hidden="true" />

--- a/docs/src/pages/_root.css
+++ b/docs/src/pages/_root.css
@@ -297,10 +297,22 @@ body:has(.rcg-home) [data-v-gutter-top] {
 
 .rcg-home-proof-lead {
   border-inline-end: 1px solid var(--rcg-border);
+  color: inherit;
   display: flex;
   flex-direction: column;
   justify-content: center;
   padding: 1.75rem 2rem;
+  text-decoration: none;
+  transition: background 150ms ease;
+}
+
+.rcg-home-proof-lead:hover {
+  background: rgb(251 146 60 / 5%);
+}
+
+.rcg-home-proof-lead:focus-visible {
+  outline: 3px solid rgb(253 186 116 / 35%);
+  outline-offset: -3px;
 }
 
 .rcg-home-proof-kicker {

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -34,6 +34,11 @@ export default defineConfig({
   topNav: [
     { text: "Docs", link: "/getting-started" },
     {
+      text: "npm",
+      link: "https://www.npmjs.com/package/rehype-code-group",
+      external: true,
+    },
+    {
       text: "GitHub",
       link: "https://github.com/ITZSHOAIB/rehype-code-group",
       external: true,

--- a/test/docs-e2e/landing.spec.ts
+++ b/test/docs-e2e/landing.spec.ts
@@ -33,6 +33,24 @@ test("presents a product landing hero with a documentation CTA", async ({
   await expect(page.getByRole("complementary")).toHaveCount(0);
 });
 
+test("links package discovery surfaces to npm", async ({ page }) => {
+  await page.goto("/");
+
+  const packageUrl = "https://www.npmjs.com/package/rehype-code-group";
+
+  await expect(
+    page.getByRole("link", { name: "View on npm", exact: true }),
+  ).toHaveAttribute("href", packageUrl);
+  await expect(
+    page.getByRole("link", { name: "npm", exact: true }),
+  ).toHaveAttribute("href", packageUrl);
+  await expect(
+    page.getByRole("link", {
+      name: "View rehype-code-group download statistics on npm",
+    }),
+  ).toHaveAttribute("href", packageUrl);
+});
+
 test("pairs the landing message with install choices and project proof points", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- add npm to the top navigation and landing-page actions
- link the download proof point to the canonical npm package page
- remove the retired playground from README navigation
- clarify how docs previews and Cloudflare production URLs actually work

## Verification
- `pnpm docs:build`
- `pnpm playwright test --config playwright.docs.config.ts --reporter=line` (23 tests)
- `pnpm lint`
- `pnpm typecheck`
- pre-commit unit coverage (38 tests)